### PR TITLE
Change functions to types.

### DIFF
--- a/iters/__init__.py
+++ b/iters/__init__.py
@@ -21,22 +21,23 @@ from iters.iters import Iter, iter, reversed, standard_iter, standard_reversed, 
 from iters.types import Ordering
 
 __all__ = (
-    # async iterator class
+    # the async iterator type
     "AsyncIter",
-    # convenient function to get async iterators
+    # the alias of the previous type
     "async_iter",
     # next functions; checked version works on any iterator, unchecked assumes async iteration
     "async_next",
     "async_next_unchecked",
-    # since we are shadowing standard functions
+    # since we are "shadowing" standard functions
     "standard_async_iter",
     "standard_async_next",
     # wrap results of function calls into async iterators
     "wrap_async_iter",
-    # iterator class
+    # the iterator type
     "Iter",
-    # convenient functions to get iterators
+    # the alias of the previous type
     "iter",
+    # the alias of `iter.reversed`
     "reversed",
     # since we are shadowing standard functions
     "standard_iter",

--- a/iters/async_iters.py
+++ b/iters/async_iters.py
@@ -20,7 +20,6 @@ from typing import (
     Reversible,
     Set,
     Tuple,
-    Type,
     TypeVar,
     Union,
     no_type_check,
@@ -259,14 +258,14 @@ if CONCURRENT:
     )
 
 __all__ = (
-    # async iterator class
+    # the async iterator type
     "AsyncIter",
-    # convenient function to get async iterators
+    # the alias of the previous type
     "async_iter",
     # next functions; checked version works on any iterator, unchecked assumes async iteration
     "async_next",
     "async_next_unchecked",
-    # since we are shadowing standard functions
+    # since we are "shadowing" standard functions
     "standard_async_iter",
     "standard_async_next",
     # wrap results of function calls into async iterators
@@ -2893,10 +2892,7 @@ class AsyncIter(AsyncIterator[T]):
             return self.create(async_wait_concurrent_bound(bound, self.iterator))
 
 
-def async_iter(
-    iterable: AnyIterable[T], async_iter_type: Type[AsyncIter[T]] = AsyncIter
-) -> AsyncIter[T]:
-    return async_iter_type(iterable)
+async_iter = AsyncIter
 
 
 def wrap_async_iter(function: Callable[PS, AnyIterable[T]]) -> Callable[PS, AsyncIter[T]]:

--- a/iters/iters.py
+++ b/iters/iters.py
@@ -18,7 +18,6 @@ from typing import (
     Reversible,
     Set,
     Tuple,
-    Type,
     TypeVar,
     Union,
     no_type_check,
@@ -165,10 +164,11 @@ from iters.utils import (
 )
 
 __all__ = (
-    # iterator class
+    # the iterator type
     "Iter",
-    # convenient functions to get iterators
+    # the alias of the previous type
     "iter",
+    # the alias of `iter.reversed`
     "reversed",
     # since we are shadowing standard functions
     "standard_iter",
@@ -2530,12 +2530,8 @@ class Iter(Iterator[T]):
         return self.create(side_effect(function, self.iterator))
 
 
-def iter(iterable: Iterable[T], iter_type: Type[Iter[T]] = Iter) -> Iter[T]:
-    return iter_type(iterable)
-
-
-def reversed(iterable: Reversible[T], iter_type: Type[Iter[T]] = Iter) -> Iter[T]:
-    return iter_type.reversed(iterable)
+iter = Iter
+reversed = iter.reversed
 
 
 def wrap_iter(function: Callable[PS, Iterable[T]]) -> Callable[PS, Iter[T]]:


### PR DESCRIPTION
This PR changes the following functions:
- `async_iter` is now an alias of `AsyncIter`
- `iter` is now an alias of `Iter`
- `reversed` is now an alias of `iter.reversed`
