### PR TITLE
Migrate to using `named` and `solus` packages.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Or by directly specifying it in the configuration like so:
 
 ```toml
 [tool.poetry.dependencies]
-iters = "^0.5.0"
+iters = "^0.6.0"
 ```
 
 Alternatively, you can add it directly from the source:

--- a/changes/18.internal.md
+++ b/changes/18.internal.md
@@ -1,1 +1,3 @@
-Migrate to using `named` and `solus` packages instead of reimplementing their functionality.
+Migrate to using [`named`](https://github.com/nekitdev/named) and
+[`solus`](https://github.com/nekitdev/solus) packages instead of
+reimplementing their functionality.

--- a/changes/18.internal.md
+++ b/changes/18.internal.md
@@ -1,0 +1,1 @@
+Migrate to using `named` and `solus` packages instead of reimplementing their functionality.

--- a/iters/__init__.py
+++ b/iters/__init__.py
@@ -11,7 +11,7 @@ __url__ = "https://github.com/nekitdev/iters"
 __title__ = "iters"
 __author__ = "nekitdev"
 __license__ = "MIT"
-__version__ = "0.5.0"
+__version__ = "0.6.0"
 
 from iters.async_iters import (
     AsyncIter,

--- a/iters/async_utils.py
+++ b/iters/async_utils.py
@@ -28,6 +28,7 @@ from typing import (
     overload,
 )
 
+from named import get_name
 from typing_extensions import Literal, Never, ParamSpec, TypeVarTuple, Unpack
 
 from iters.concurrent import CONCURRENT
@@ -66,7 +67,6 @@ from iters.typing import (
     Tuple7,
     Tuple8,
     Unary,
-    get_name,
     is_async_iterable,
     is_async_iterator,
     is_bytes,

--- a/iters/types.py
+++ b/iters/types.py
@@ -4,7 +4,7 @@ from enum import Enum
 from threading import Lock
 from typing import Any, Type, TypeVar
 
-from iters.typing import get_name
+from solus import Singleton
 
 __all__ = (
     # ordering
@@ -99,44 +99,17 @@ class Ordering(Enum):
         return self.is_greater() or self.is_equal()
 
 
-S = TypeVar("S")
-
-
-class SingletonType(type):
-    _INSTANCES = {}  # type: ignore
-    _LOCK = Lock()
-
-    def __call__(cls: Type[S], *args: Any, **kwargs: Any) -> S:
-        instances = cls._INSTANCES  # type: ignore
-        lock = cls._LOCK  # type: ignore
-
-        # use double-checked locking
-
-        if cls not in instances:
-            with lock:
-                if cls not in instances:
-                    instances[cls] = super().__call__(*args, **kwargs)  # type: ignore
-
-        return instances[cls]  # type: ignore
-
-
-class Singleton(metaclass=SingletonType):
-    def __repr__(self) -> str:
-        return get_name(type(self))
-
-
-singleton = Singleton()
-
-
 class NoDefault(Singleton):
-    pass
+    """Represents the absence of default values."""
 
 
 no_default = NoDefault()
+"""The instance of [`NoDefault`][iters.types.NoDefault]."""
 
 
 class Marker(Singleton):
-    pass
+    """Represents markers used for various checks."""
 
 
 marker = Marker()
+"""The instance of [`Marker`][iters.types.Marker]."""

--- a/iters/typing.py
+++ b/iters/typing.py
@@ -79,10 +79,6 @@ __all__ = (
     # unions
     "AnyIterable",
     "AnyIterator",
-    # named
-    "Named",
-    "get_name",
-    "is_named",
     # checks
     "is_async_iterable",
     "is_async_iterator",
@@ -271,19 +267,3 @@ class Product(Protocol):
     @abstractmethod
     def __mul__(self: P, __other: P) -> P:
         raise NotImplementedError
-
-
-NAME = "__name__"
-
-
-@runtime_checkable
-class Named(Protocol):
-    __name__: str
-
-
-def is_named(item: Any) -> TypeGuard[Named]:
-    return hasattr(item, NAME)
-
-
-def get_name(item: Named) -> str:
-    return item.__name__

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "iters"
-version = "0.5.0"
+version = "0.6.0"
 description = "Composable external iteration."
 authors = ["nekitdev"]
 license = "MIT"
@@ -32,6 +32,9 @@ include = "iters"
 [tool.poetry.dependencies]
 python = ">= 3.7"
 typing-extensions = ">= 4.3.0"
+
+named = ">= 1.1.0"
+solus = ">= 1.0.1"
 
 [tool.poetry.dependencies.anyio]
 version = ">= 3.6.1"
@@ -131,7 +134,7 @@ warn_unused_ignores = false  # compatibility
 
 [tool.changelogging]
 name = "iters"
-version = "0.5.0"
+version = "0.6.0"
 url = "https://github.com/nekitdev/iters"
 directory = "changes"
 output = "CHANGELOG.md"


### PR DESCRIPTION
Migrate to using [`named`](https://github.com/nekitdev/named) and [`solus`](https://github.com/nekitdev/solus) packages instead of reimplementing their functionality.
