### PR TITLE
Refactor Wraps Usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 <!-- changelogging: start -->
 
+## 0.19.0 (2024-10-02)
+
+### Changes
+
+- Migrated to the latest version of the `wraps` library.
+
 ## 0.18.0 (2024-04-23)
 
 ### Changes

--- a/iters/async_iters.py
+++ b/iters/async_iters.py
@@ -61,9 +61,11 @@ from typing_aliases import (
 )
 from typing_extensions import Never, ParamSpec
 from wraps.early.decorators import early_option_await
-from wraps.primitives.option import Option, Some
-from wraps.primitives.result import Result
-from wraps.wraps.futures import wrap_future, wrap_future_option, wrap_future_result
+from wraps.option import Option, Some
+from wraps.result import Result
+from wraps.futures.future import wrap_future
+from wraps.futures.optiion import wrap_future_option
+from wraps.futures.result import wrap_future_result
 
 from iters.async_utils import (
     async_accumulate_fold,

--- a/iters/async_iters.py
+++ b/iters/async_iters.py
@@ -64,7 +64,7 @@ from wraps.early.decorators import early_option_await
 from wraps.option import Option, Some
 from wraps.result import Result
 from wraps.futures.future import wrap_future
-from wraps.futures.optiion import wrap_future_option
+from wraps.futures.option import wrap_future_option
 from wraps.futures.result import wrap_future_result
 
 from iters.async_utils import (

--- a/iters/async_wraps.py
+++ b/iters/async_wraps.py
@@ -64,12 +64,12 @@ async def async_exactly_one(iterable: AnyIterable[T]) -> Result[T, Option[AsyncI
     first = await async_next_unchecked(iterator, marker)
 
     if is_marker(first):
-        return Error(NULL)
+        return Err(NULL)
 
     second = await async_next_unchecked(iterator, marker)
 
     if not is_marker(second):
-        return Error(Some(async_chain((first, second), iterator)))
+        return Err(Some(async_chain((first, second), iterator)))
 
     return Ok(first)
 
@@ -85,6 +85,6 @@ async def async_at_most_one(iterable: AnyIterable[T]) -> Result[Option[T], Async
     second = await async_next_unchecked(iterator, marker)
 
     if not is_marker(second):
-        return Error(async_chain((first, second), iterator))
+        return Err(async_chain((first, second), iterator))
 
     return Ok(Some(first))

--- a/iters/async_wraps.py
+++ b/iters/async_wraps.py
@@ -2,7 +2,7 @@ from typing import AsyncIterator, TypeVar
 
 from typing_aliases import AnyIterable, AsyncBinary, AsyncUnary, Binary, Unary
 from wraps.option import NULL, Option, Some
-from wraps.result import Error, Ok, Result
+from wraps.result import Err, Ok, Result
 
 from iters.async_utils import async_chain, async_iter, async_next_unchecked
 from iters.types import is_marker, marker

--- a/iters/async_wraps.py
+++ b/iters/async_wraps.py
@@ -1,8 +1,8 @@
 from typing import AsyncIterator, TypeVar
 
 from typing_aliases import AnyIterable, AsyncBinary, AsyncUnary, Binary, Unary
-from wraps.primitives.option import NULL, Option, Some
-from wraps.primitives.result import Error, Ok, Result
+from wraps.option import NULL, Option, Some
+from wraps.result import Error, Ok, Result
 
 from iters.async_utils import async_chain, async_iter, async_next_unchecked
 from iters.types import is_marker, marker

--- a/iters/iters.py
+++ b/iters/iters.py
@@ -49,8 +49,8 @@ from typing_aliases import (
 )
 from typing_extensions import Never, ParamSpec
 from wraps.early.decorators import early_option
-from wraps.primitives.option import Option, Some
-from wraps.primitives.result import Result
+from wraps.option import Option, Some
+from wraps.result import Result
 
 from iters.constants import DEFAULT_START, DEFAULT_STEP, EMPTY_BYTES, EMPTY_STRING
 from iters.ordered_set import OrderedSet, ordered_set

--- a/iters/mapping_view.py
+++ b/iters/mapping_view.py
@@ -2,7 +2,7 @@ from typing import Any, Iterator, Mapping, TypeVar, final
 
 from attrs import frozen
 from typing_extensions import Self
-from wraps.wraps.option import wrap_option_on
+from wraps.option import wrap_option_on
 
 __all__ = ("MappingView", "mapping_view")
 

--- a/iters/ordered_set.py
+++ b/iters/ordered_set.py
@@ -19,7 +19,7 @@ from mixed_methods import mixed_method
 from named import get_type_name
 from typing_aliases import AnySet, is_instance, is_sized, is_slice
 from typing_extensions import TypeIs
-from wraps.wraps.option import wrap_option_on
+from wraps.option import wrap_option_on
 
 __all__ = ("OrderedSet", "ordered_set", "ordered_set_unchecked")
 

--- a/iters/sequence_view.py
+++ b/iters/sequence_view.py
@@ -4,7 +4,7 @@ from typing import Sequence, TypeVar, Union, final, overload
 
 from attrs import frozen
 from typing_aliases import is_slice
-from wraps.wraps.option import wrap_option_on
+from wraps.option import wrap_option_on
 
 __all__ = ("SequenceView", "sequence_view")
 

--- a/iters/types.py
+++ b/iters/types.py
@@ -4,7 +4,7 @@ from typing import Any, TypeVar, Union
 
 from solus import Singleton
 from typing_extensions import TypeIs
-from wraps.primitives.option import NULL, Option, Some
+from wraps.option import NULL, Option, Some
 
 T = TypeVar("T")
 

--- a/iters/wraps.py
+++ b/iters/wraps.py
@@ -2,7 +2,7 @@ from typing import Iterable, Iterator, TypeVar
 
 from typing_aliases import Binary, Unary
 from wraps.option import NULL, Option, Some
-from wraps.result import Error, Ok, Result
+from wraps.result import Err, Ok, Result
 
 from iters.types import is_marker, marker
 from iters.utils import chain

--- a/iters/wraps.py
+++ b/iters/wraps.py
@@ -1,8 +1,8 @@
 from typing import Iterable, Iterator, TypeVar
 
 from typing_aliases import Binary, Unary
-from wraps.primitives.option import NULL, Option, Some
-from wraps.primitives.result import Error, Ok, Result
+from wraps.option import NULL, Option, Some
+from wraps.result import Error, Ok, Result
 
 from iters.types import is_marker, marker
 from iters.utils import chain

--- a/iters/wraps.py
+++ b/iters/wraps.py
@@ -37,12 +37,12 @@ def exactly_one(iterable: Iterable[T]) -> Result[T, Option[Iterator[T]]]:
     first = next(iterator, marker)
 
     if is_marker(first):
-        return Error(NULL)
+        return Err(NULL)
 
     second = next(iterator, marker)
 
     if not is_marker(second):
-        return Error(Some(chain((first, second), iterator)))
+        return Err(Some(chain((first, second), iterator)))
 
     return Ok(first)
 
@@ -58,6 +58,6 @@ def at_most_one(iterable: Iterable[T]) -> Result[Option[T], Iterator[T]]:
     second = next(iterator, marker)
 
     if not is_marker(second):
-        return Error(chain((first, second), iterator))
+        return Err(chain((first, second), iterator))
 
     return Ok(Some(first))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ async-extensions = ">= 4.0.0"
 mixed-methods = ">= 1.1.1"
 
 funcs = ">= 0.10.1"
-wraps = ">= 0.11.0"
+wraps = ">= 0.15.0"
 
 [tool.poetry.group.format.dependencies]
 ruff = "0.4.1"


### PR DESCRIPTION
Wraps library has been refactored in latest update, which is giving errors in `iters` usage as it always installs latest `wraps library [Wraps library changes](https://github.com/nekitdev/wraps/commit/e33875ec98e2720ea304d7162c01b06e0c3da374)